### PR TITLE
build: bump xhgui base image to 0.23.2

### DIFF
--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,20 +1,4 @@
-FROM xhgui/xhgui:0.21 AS xhgui-docker
-
-FROM scratch AS ddev-xhgui
-
-### --------------------------------xhgui-docker----------------------------------
-### XHGui Docker image creates a volume for /run/nginx, which we want to remove.
-### We copy all files from xhgui/xhgui, and set ENV, WORKDIR, CMD, EXPOSE.
-### Source https://github.com/perftools/xhgui/blob/0.21.x/Dockerfile
-COPY --from=xhgui-docker / /
-ENV PHP_INI_DIR=/etc/php7
-ARG APPDIR=/var/www/xhgui
-ARG WEBROOT=$APPDIR/webroot
-WORKDIR $APPDIR
-RUN mkdir -p /run/nginx
-CMD ["sh", "-c", "nginx && exec php-fpm"]
-EXPOSE 80
-### ------------------------------END xhgui-docker--------------------------------
+FROM xhgui/xhgui:0.23.x AS ddev-xhgui
 
 RUN apk add bash curl
 ADD /var /var

--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,4 +1,4 @@
-FROM xhgui/xhgui:0.23.x AS ddev-xhgui
+FROM xhgui/xhgui:0.23.0 AS ddev-xhgui
 
 RUN apk add bash curl
 ADD /var /var

--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,4 +1,4 @@
-FROM xhgui/xhgui:0.23.0 AS ddev-xhgui
+FROM xhgui/xhgui:0.23 AS ddev-xhgui
 
 RUN apk add bash curl
 ADD /var /var

--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,6 +1,6 @@
 FROM xhgui/xhgui:0.23 AS ddev-xhgui
 
-RUN apk add bash curl
+RUN apk add --no-cache bash curl
 ADD /var /var
 ADD /etc /etc
 RUN echo 'memory_limit=512M' >> $PHP_INI_DIR/conf.d/99-memory-limit.ini

--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,4 +1,4 @@
-FROM xhgui/xhgui:0.23 AS ddev-xhgui
+FROM xhgui/xhgui:0.23.2 AS ddev-xhgui
 
 RUN apk add --no-cache bash curl
 ADD /var /var

--- a/containers/ddev-xhgui/var/www/xhgui/config/config.php
+++ b/containers/ddev-xhgui/var/www/xhgui/config/config.php
@@ -17,6 +17,7 @@ return [
         'pass' => getenv('XHGUI_PDO_PASS') ?: 'db',
         'table' => getenv('XHGUI_PDO_TABLE') ?: 'results',
         'tableWatch' => getenv('XHGUI_PDO_TABLE_WATCHES') ?: 'watches',
+        'initSchema' => getenv('XHGUI_PDO_INIT_SCHEMA') ?: 'true',
     ],
 
     'run.view.filter.names' => [

--- a/containers/ddev-xhgui/var/www/xhgui/config/config.php
+++ b/containers/ddev-xhgui/var/www/xhgui/config/config.php
@@ -17,7 +17,7 @@ return [
         'pass' => getenv('XHGUI_PDO_PASS') ?: 'db',
         'table' => getenv('XHGUI_PDO_TABLE') ?: 'results',
         'tableWatch' => getenv('XHGUI_PDO_TABLE_WATCHES') ?: 'watches',
-        'initSchema' => getenv('XHGUI_PDO_INIT_SCHEMA') ?: 'true',
+        'initSchema' => getenv('XHGUI_PDO_INITSCHEMA') ?: 'true',
     ],
 
     'run.view.filter.names' => [

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -38,7 +38,7 @@ var BusyboxImage = "busybox:stable"
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "20250325_stasadev_xhgui_volume"
+var XhguiTag = "20250328_stasadev_xhgui_0.23.x"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities"


### PR DESCRIPTION
**This PR targets the stasadev:20250328_stasadev_xhgui_0.23.x branch to update the already open PR** https://github.com/ddev/ddev/pull/7161 

## The Issue

Bumps the base image version to 0.23.2. New version is based on PHP 8.3 instead of PHP 7.4/8.0.
Also includes a small fix for the custom view when using the PdoSearcher (like we do on ddev).

## Manual Testing Instructions

```
ddev xhgui
ddev logs -s xhgui -f
```
