### PR TITLE
feat(utility): add --all flag, label add-on files by name in check-custom-config

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -110,7 +110,7 @@ if [ "${OSTYPE%-*}" = "linux" ]; then
 fi
 
 header "existing project customizations"
-ddev utility check-custom-config || true
+ddev utility check-custom-config --all || true
 
 header "installed DDEV add-ons"
 

--- a/cmd/ddev/cmd/utility-check-custom-config.go
+++ b/cmd/ddev/cmd/utility-check-custom-config.go
@@ -10,16 +10,25 @@ import (
 var UtilityCheckCustomConfig = &cobra.Command{
 	Use:   "check-custom-config",
 	Short: "Display custom configuration files in the current project",
-	Run: func(_ *cobra.Command, _ []string) {
+	Long: `Display custom configuration files in the current project.
+
+By default, shows only files that would warn on startup (user-created files
+without a #ddev-generated or #ddev-silent-no-warn marker).
+
+Use --all to also show add-on files (marked #ddev-generated) and silenced
+files (marked #ddev-silent-no-warn).`,
+	Run: func(cmd *cobra.Command, _ []string) {
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
 			util.Failed("Can't find active project: %v", err)
 		}
 
-		app.CheckCustomConfig(true)
+		showAll, _ := cmd.Flags().GetBool("all")
+		app.CheckCustomConfig(showAll)
 	},
 }
 
 func init() {
+	UtilityCheckCustomConfig.Flags().Bool("all", false, "Include add-on files (#ddev-generated) and silenced files (#ddev-silent-no-warn)")
 	DebugCmd.AddCommand(UtilityCheckCustomConfig)
 }

--- a/cmd/ddev/cmd/utility-check-custom-config.go
+++ b/cmd/ddev/cmd/utility-check-custom-config.go
@@ -15,8 +15,8 @@ var UtilityCheckCustomConfig = &cobra.Command{
 By default, shows only files that would warn on startup (user-created files
 without a #ddev-generated or #ddev-silent-no-warn marker).
 
-Use --all to also show add-on files (marked #ddev-generated) and silenced
-files (marked #ddev-silent-no-warn).`,
+Use --all to also show add-on files (labeled "addon <name>") and silenced
+files (labeled #ddev-silent-no-warn).`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
@@ -29,6 +29,6 @@ files (marked #ddev-silent-no-warn).`,
 }
 
 func init() {
-	UtilityCheckCustomConfig.Flags().Bool("all", false, "Include add-on files (#ddev-generated) and silenced files (#ddev-silent-no-warn)")
+	UtilityCheckCustomConfig.Flags().Bool("all", false, `Include add-on files (labeled "addon <name>") and silenced files (#ddev-silent-no-warn)`)
 	DebugCmd.AddCommand(UtilityCheckCustomConfig)
 }

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -38,7 +38,13 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 
 	// Test with no custom config
 	t.Run("no custom config", func(t *testing.T) {
+		// Default mode: no output when nothing to warn about
 		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
+		require.NoError(t, err)
+		require.NotContains(t, out, "Custom configuration detected")
+
+		// --all mode: explicit success message
+		out, err = exec.RunCommand(DdevBin, []string{"utility", "check-custom-config", "--all"})
 		require.NoError(t, err)
 		require.Contains(t, out, "No custom configuration detected in project '"+projectName+"'.")
 	})
@@ -74,8 +80,13 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		err := os.WriteFile(silencedFile, []byte("#ddev-silent-no-warn\nmemory_limit = 256M\n"), 0644)
 		require.NoError(t, err)
 
-		// Run check-custom-config (should show all including silenced)
+		// Default mode: silenced file should not appear
 		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
+		require.NoError(t, err)
+		require.NotContains(t, out, "silenced.ini")
+
+		// --all mode: silenced file should appear with marker
+		out, err = exec.RunCommand(DdevBin, []string{"utility", "check-custom-config", "--all"})
 		require.NoError(t, err)
 		require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
 		require.Contains(t, out, "PHP")
@@ -143,11 +154,15 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		_, err := exec.RunCommand(DdevBin, []string{"add-on", "get", "ddev/ddev-phpmyadmin"})
 		require.NoError(t, err)
 
-		// Run check-custom-config
+		// Default mode: addon files should not appear (they are not user custom files)
 		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
 		require.NoError(t, err)
+		require.NotContains(t, out, "docker-compose.phpmyadmin.yaml")
+
+		// --all mode: addon files should appear with (#ddev-generated) marker
+		out, err = exec.RunCommand(DdevBin, []string{"utility", "check-custom-config", "--all"})
+		require.NoError(t, err)
 		require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
-		// Should show addon files with (#ddev-generated) marker
 		require.Contains(t, out, "docker-compose.phpmyadmin.yaml")
 		require.Contains(t, out, "(#ddev-generated)")
 	})

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -164,6 +164,6 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
 		require.Contains(t, out, "docker-compose.phpmyadmin.yaml")
-		require.Contains(t, out, "(#ddev-generated)")
+		require.Contains(t, out, "(addon ddev-phpmyadmin)")
 	})
 }

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1480,16 +1480,20 @@ ddevcd some-project
 
 ### `utility check-custom-config`
 
-Display all configuration in the project's `.ddev` directory, including custom files, add-on files, and silenced files.
+Display custom configuration files in the current project's `.ddev` directory.
 
-Files are marked with:
+By default, shows only files that would warn on startup (user-created files without a `#ddev-generated` or `#ddev-silent-no-warn` marker). Use `--all` to also show add-on files and silenced files.
+
+When `--all` is used, files are marked with:
 
 * `(#ddev-generated)` for files from add-ons
 * `(#ddev-silent-no-warn)` for silenced files
 
 ```shell
-# Check the project's .ddev directory custom configuration
+# Show only files that would warn on startup
 ddev utility check-custom-config
+# Show all files including add-on and silenced files
+ddev utility check-custom-config --all
 ```
 
 ### `utility check-db-match`

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1484,9 +1484,9 @@ Display custom configuration files in the current project's `.ddev` directory.
 
 By default, shows only files that would warn on startup (user-created files without a `#ddev-generated` or `#ddev-silent-no-warn` marker). Use `--all` to also show add-on files and silenced files.
 
-When `--all` is used, files are marked with:
+When `--all` is used, files are annotated with:
 
-* `(#ddev-generated)` for files from add-ons
+* `(addon <name>)` for files from a named add-on
 * `(#ddev-silent-no-warn)` for silenced files
 
 ```shell

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -27,16 +28,17 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) {
 
 	// Gather expected add-on files from the manifest
 	// When showAll=false: use this to filter out add-on files (don't show them)
-	// When showAll=true: use this to mark add-on files with (#ddev-generated)
-	var expectedAddonFiles []string
+	// When showAll=true: use this to label add-on files with (addon <name>)
+	addonFileMap := make(map[string]string) // file path -> addon name
 	manifest, err := GatherAllManifests(app)
 	if err == nil {
 		for _, addon := range manifest {
 			for _, relPath := range addon.ProjectFiles {
-				expectedAddonFiles = append(expectedAddonFiles, app.GetConfigPath(relPath))
+				addonFileMap[app.GetConfigPath(relPath)] = addon.Name
 			}
 		}
 	}
+	addonFileSlice := slices.Collect(maps.Keys(addonFileMap))
 
 	// Define all configuration checks
 	checks := []customConfigCheck{
@@ -103,7 +105,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) {
 				if showAll {
 					return nil
 				}
-				return expectedAddonFiles
+				return addonFileSlice
 			},
 			displayName: "Database",
 		},
@@ -237,7 +239,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) {
 				if showAll {
 					return nil
 				}
-				return expectedAddonFiles
+				return addonFileSlice
 			},
 			displayName: "Web server",
 		},
@@ -255,7 +257,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) {
 				if showAll {
 					return nil
 				}
-				return expectedAddonFiles
+				return addonFileSlice
 			},
 			displayName: "Config",
 		},
@@ -267,7 +269,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) {
 				if showAll {
 					return nil
 				}
-				return expectedAddonFiles
+				return addonFileSlice
 			},
 			displayName: "Docker Compose",
 		},
@@ -308,7 +310,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) {
 		if check.expectedDdevFiles != nil {
 			expectedFiles = check.expectedDdevFiles()
 		}
-		customFiles := filterCustomConfigFiles(files, expectedFiles, expectedAddonFiles, showAll)
+		customFiles := filterCustomConfigFiles(files, expectedFiles, addonFileMap, showAll)
 
 		if len(customFiles) > 0 {
 			findings = append(findings, finding{
@@ -337,25 +339,11 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) {
 		for _, category := range categoryOrder {
 			files := categoryFiles[category]
 			if len(files) == 1 {
-				filePath := files[0].path
-				if files[0].ddevGenerated {
-					filePath += " (#ddev-generated)"
-				}
-				if files[0].silentNoWarn {
-					filePath += " (#ddev-silent-no-warn)"
-				}
-				_, _ = fmt.Fprintf(&message, "  • %s: %s\n", category, filePath)
+				_, _ = fmt.Fprintf(&message, "  • %s: %s\n", category, fileLabel(files[0]))
 			} else {
 				_, _ = fmt.Fprintf(&message, "  • %s:\n", category)
 				for _, file := range files {
-					filePath := file.path
-					if file.ddevGenerated {
-						filePath += " (#ddev-generated)"
-					}
-					if file.silentNoWarn {
-						filePath += " (#ddev-silent-no-warn)"
-					}
-					_, _ = fmt.Fprintf(&message, "    - %s\n", filePath)
+					_, _ = fmt.Fprintf(&message, "    - %s\n", fileLabel(file))
 				}
 			}
 		}
@@ -411,43 +399,46 @@ func isCustomConfigFile(filePath string, expectedDdevFiles []string, showAll boo
 
 // fileInfo represents a config file with metadata
 type fileInfo struct {
-	path          string
-	ddevGenerated bool
-	silentNoWarn  bool
+	path         string
+	addonName    string // non-empty if file belongs to an add-on
+	silentNoWarn bool
 }
 
 // filterCustomConfigFiles returns only files that qualify as custom config files.
 // expectedDdevFiles is an optional list of files that are expected to have DDEV markers (core DDEV files).
-// expectedAddonFiles is a list of addon-generated files that should be marked when showAll=true.
+// addonFileMap maps file paths to their add-on name for files managed by installed add-ons.
 // Files with DDEV markers that are NOT in expectedDdevFiles list are considered suspicious and flagged as custom.
-// If showAll is true, add-on files are shown with (#ddev-generated) marker and silenced files with (#ddev-silent-no-warn) marker.
-func filterCustomConfigFiles(files []string, expectedDdevFiles []string, expectedAddonFiles []string, showAll bool) []fileInfo {
+// If showAll is true, add-on files are shown with (addon <name>) and silenced files with (#ddev-silent-no-warn).
+func filterCustomConfigFiles(files []string, expectedDdevFiles []string, addonFileMap map[string]string, showAll bool) []fileInfo {
 	var out []fileInfo
 	for _, f := range files {
-		// Check if file is an add-on file
-		isAddonFile := slices.Contains(expectedAddonFiles, f)
+		addonName := addonFileMap[f] // empty string if not an add-on file
 
-		// Check if file has markers
 		isSilenced := false
-		isDdevGenerated := false
 		if showAll {
 			silentNoWarnFound, _ := fileutil.FgrepStringInFile(f, nodeps.DdevSilentNoWarn)
 			isSilenced = silentNoWarnFound
-
-			// Mark add-on files with #ddev-generated
-			if isAddonFile {
-				ddevGenFound, _ := fileutil.FgrepStringInFile(f, nodeps.DdevFileSignature)
-				isDdevGenerated = ddevGenFound
-			}
 		}
 
 		if isCustomConfigFile(f, expectedDdevFiles, showAll) {
 			out = append(out, fileInfo{
-				path:          f,
-				ddevGenerated: isDdevGenerated,
-				silentNoWarn:  isSilenced,
+				path:         f,
+				addonName:    addonName,
+				silentNoWarn: isSilenced,
 			})
 		}
 	}
 	return out
+}
+
+// fileLabel returns the display string for a file, appending annotation tags as needed.
+func fileLabel(f fileInfo) string {
+	label := f.path
+	if f.addonName != "" {
+		label += " (addon " + f.addonName + ")"
+	}
+	if f.silentNoWarn {
+		label += " (#ddev-silent-no-warn)"
+	}
+	return label
 }


### PR DESCRIPTION
## The Issue

Suggestions on top of #8218 (ddev/ddev). (Just suggestions. Claude got away from me chasing these.)

## How This PR Solves The Issue

1. **`--all` flag** (default off): `ddev utility check-custom-config` now defaults to showing only files that would warn on startup, matching `ddev start` behavior. Use `--all` to also show add-on files and silenced files. This avoids confusion where users see add-on files listed as "custom config" when auditing their own customizations.

2. **Named add-on labels**: Add-on files are now labeled `(addon <name>)` instead of `(#ddev-generated)`, using the add-on name from the manifest. This makes it immediately clear which add-on owns each file:
   ```
   • Docker Compose:
     - docker-compose.redis.yaml (addon redis)
     - docker-compose.solr.yaml (addon solr)
   ```

3. **`test_ddev.sh`** updated to use `--all` for the diagnostic audit header, so the full picture is shown in test output.

## Manual Testing Instructions

```bash
# Default mode: shows only startup-warning files
ddev utility check-custom-config

# --all mode: shows add-on files (labeled by name) and silenced files
ddev utility check-custom-config --all
```

## Automated Testing Overview

Tests updated to cover both modes explicitly for silenced files and add-on files.

## Release/Deployment Notes

`--all` is additive — default behavior is more conservative than before (add-on files no longer shown without the flag).